### PR TITLE
feat(#7): 회원가입 도메인 (User) + SecurityConfig 최소 세팅

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,9 +22,13 @@ dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-security")
 	implementation("org.springframework.boot:spring-boot-starter-validation")
 	implementation("org.springframework.boot:spring-boot-starter-web")
+	compileOnly("org.projectlombok:lombok")
+	annotationProcessor("org.projectlombok:lombok")
 	runtimeOnly("com.h2database:h2")
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 	testImplementation("org.springframework.security:spring-security-test")
+	testCompileOnly("org.projectlombok:lombok")
+	testAnnotationProcessor("org.projectlombok:lombok")
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 

--- a/src/main/java/com/example/board/common/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/board/common/GlobalExceptionHandler.java
@@ -1,0 +1,48 @@
+package com.example.board.common;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.time.LocalDateTime;
+import java.util.stream.Collectors;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    public record ErrorResponse(
+            LocalDateTime timestamp,
+            int status,
+            String error,
+            String message,
+            String path
+    ) {}
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleValidation(
+            MethodArgumentNotValidException e, HttpServletRequest req) {
+        String message = e.getBindingResult().getFieldErrors().stream()
+                .map(fe -> fe.getField() + " " + fe.getDefaultMessage())
+                .collect(Collectors.joining(", "));
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ErrorResponse(
+                LocalDateTime.now(),
+                HttpStatus.BAD_REQUEST.value(),
+                HttpStatus.BAD_REQUEST.getReasonPhrase(),
+                message,
+                req.getRequestURI()));
+    }
+
+    @ExceptionHandler(DataIntegrityViolationException.class)
+    public ResponseEntity<ErrorResponse> handleDuplicate(
+            DataIntegrityViolationException e, HttpServletRequest req) {
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(new ErrorResponse(
+                LocalDateTime.now(),
+                HttpStatus.CONFLICT.value(),
+                HttpStatus.CONFLICT.getReasonPhrase(),
+                "username already exists",
+                req.getRequestURI()));
+    }
+}

--- a/src/main/java/com/example/board/common/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/board/common/GlobalExceptionHandler.java
@@ -27,22 +27,22 @@ public class GlobalExceptionHandler {
         String message = e.getBindingResult().getFieldErrors().stream()
                 .map(fe -> fe.getField() + " " + fe.getDefaultMessage())
                 .collect(Collectors.joining(", "));
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ErrorResponse(
-                LocalDateTime.now(),
-                HttpStatus.BAD_REQUEST.value(),
-                HttpStatus.BAD_REQUEST.getReasonPhrase(),
-                message,
-                req.getRequestURI()));
+        return build(HttpStatus.BAD_REQUEST, message, req);
     }
 
     @ExceptionHandler(DataIntegrityViolationException.class)
     public ResponseEntity<ErrorResponse> handleDuplicate(
             DataIntegrityViolationException e, HttpServletRequest req) {
-        return ResponseEntity.status(HttpStatus.CONFLICT).body(new ErrorResponse(
+        return build(HttpStatus.CONFLICT, "username already exists", req);
+    }
+
+    private static ResponseEntity<ErrorResponse> build(
+            HttpStatus status, String message, HttpServletRequest req) {
+        return ResponseEntity.status(status).body(new ErrorResponse(
                 LocalDateTime.now(),
-                HttpStatus.CONFLICT.value(),
-                HttpStatus.CONFLICT.getReasonPhrase(),
-                "username already exists",
+                status.value(),
+                status.getReasonPhrase(),
+                message,
                 req.getRequestURI()));
     }
 }

--- a/src/main/java/com/example/board/config/SecurityConfig.java
+++ b/src/main/java/com/example/board/config/SecurityConfig.java
@@ -1,0 +1,32 @@
+package com.example.board.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        return http
+                .csrf(csrf -> csrf.disable())
+                .headers(headers -> headers.frameOptions(frame -> frame.disable()))
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(HttpMethod.POST, "/api/auth/signup").permitAll()
+                        .requestMatchers("/h2-console/**").permitAll()
+                        .anyRequest().authenticated())
+                .build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/example/board/user/AuthController.java
+++ b/src/main/java/com/example/board/user/AuthController.java
@@ -1,0 +1,25 @@
+package com.example.board.user;
+
+import com.example.board.user.dto.SignupRequest;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final UserService userService;
+
+    @PostMapping("/signup")
+    public ResponseEntity<Void> signup(@Valid @RequestBody SignupRequest request) {
+        userService.signup(request);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+}

--- a/src/main/java/com/example/board/user/User.java
+++ b/src/main/java/com/example/board/user/User.java
@@ -1,0 +1,43 @@
+package com.example.board.user;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "users", uniqueConstraints = @UniqueConstraint(columnNames = "username"))
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true, length = 50)
+    private String username;
+
+    @Column(nullable = false, length = 100)
+    private String password;
+
+    @Column(nullable = false, length = 30)
+    private String nickname;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    public User(String username, String passwordHash, String nickname) {
+        this.username = username;
+        this.password = passwordHash;
+        this.nickname = nickname;
+        this.createdAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/example/board/user/UserRepository.java
+++ b/src/main/java/com/example/board/user/UserRepository.java
@@ -1,0 +1,11 @@
+package com.example.board.user;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    boolean existsByUsername(String username);
+
+    Optional<User> findByUsername(String username);
+}

--- a/src/main/java/com/example/board/user/UserService.java
+++ b/src/main/java/com/example/board/user/UserService.java
@@ -2,8 +2,10 @@ package com.example.board.user;
 
 import com.example.board.user.dto.SignupRequest;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -12,7 +14,16 @@ public class UserService {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
 
+    @Transactional
     public User signup(SignupRequest request) {
-        throw new UnsupportedOperationException("RED — #7 GREEN 커밋에서 구현");
+        if (userRepository.existsByUsername(request.username())) {
+            throw new DataIntegrityViolationException(
+                    "username duplicated: " + request.username());
+        }
+        User user = new User(
+                request.username(),
+                passwordEncoder.encode(request.password()),
+                request.nickname());
+        return userRepository.save(user);
     }
 }

--- a/src/main/java/com/example/board/user/UserService.java
+++ b/src/main/java/com/example/board/user/UserService.java
@@ -1,0 +1,18 @@
+package com.example.board.user;
+
+import com.example.board.user.dto.SignupRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public User signup(SignupRequest request) {
+        throw new UnsupportedOperationException("RED — #7 GREEN 커밋에서 구현");
+    }
+}

--- a/src/main/java/com/example/board/user/dto/SignupRequest.java
+++ b/src/main/java/com/example/board/user/dto/SignupRequest.java
@@ -1,0 +1,19 @@
+package com.example.board.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record SignupRequest(
+        @NotBlank
+        @Size(min = 3, max = 50)
+        String username,
+
+        @NotBlank
+        @Size(min = 6, max = 100)
+        String password,
+
+        @NotBlank
+        @Size(max = 30)
+        String nickname
+) {
+}

--- a/src/test/java/com/example/board/user/AuthControllerTest.java
+++ b/src/test/java/com/example/board/user/AuthControllerTest.java
@@ -1,0 +1,88 @@
+package com.example.board.user;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.example.board.config.SecurityConfig;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(AuthController.class)
+@Import(SecurityConfig.class)
+class AuthControllerTest {
+
+    @Autowired
+    MockMvc mvc;
+
+    @MockBean
+    UserService userService;
+
+    static Stream<Arguments> invalidPayloads() {
+        return Stream.of(
+                Arguments.of("username null",
+                        "{\"password\":\"pw1234!\",\"nickname\":\"앨리스\"}"),
+                Arguments.of("username blank",
+                        "{\"username\":\"\",\"password\":\"pw1234!\",\"nickname\":\"앨리스\"}"),
+                Arguments.of("username too short",
+                        "{\"username\":\"ab\",\"password\":\"pw1234!\",\"nickname\":\"앨리스\"}"),
+                Arguments.of("username too long",
+                        "{\"username\":\"" + "a".repeat(51) + "\",\"password\":\"pw1234!\",\"nickname\":\"앨리스\"}"),
+                Arguments.of("password null",
+                        "{\"username\":\"alice\",\"nickname\":\"앨리스\"}"),
+                Arguments.of("password blank",
+                        "{\"username\":\"alice\",\"password\":\"\",\"nickname\":\"앨리스\"}"),
+                Arguments.of("password too short",
+                        "{\"username\":\"alice\",\"password\":\"pw12\",\"nickname\":\"앨리스\"}"),
+                Arguments.of("nickname null",
+                        "{\"username\":\"alice\",\"password\":\"pw1234!\"}"),
+                Arguments.of("nickname blank",
+                        "{\"username\":\"alice\",\"password\":\"pw1234!\",\"nickname\":\"\"}")
+        );
+    }
+
+    @ParameterizedTest(name = "{0} → 400")
+    @MethodSource("invalidPayloads")
+    void signup_invalidPayload_returns400(String caseName, String body) throws Exception {
+        mvc.perform(post("/api/auth/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void signup_validPayload_returns201() throws Exception {
+        String body = "{\"username\":\"alice\",\"password\":\"pw1234!\",\"nickname\":\"앨리스\"}";
+
+        mvc.perform(post("/api/auth/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isCreated());
+
+        verify(userService).signup(any());
+    }
+
+    @Test
+    void signup_duplicateUsername_returns409() throws Exception {
+        doThrow(new DataIntegrityViolationException("username duplicated"))
+                .when(userService).signup(any());
+        String body = "{\"username\":\"alice\",\"password\":\"pw1234!\",\"nickname\":\"앨리스\"}";
+
+        mvc.perform(post("/api/auth/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isConflict());
+    }
+}

--- a/src/test/java/com/example/board/user/UserServiceTest.java
+++ b/src/test/java/com/example/board/user/UserServiceTest.java
@@ -1,0 +1,72 @@
+package com.example.board.user;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.example.board.user.dto.SignupRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+
+    @Mock
+    UserRepository userRepository;
+
+    BCryptPasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
+
+    UserService userService;
+
+    @BeforeEach
+    void setUp() {
+        userService = new UserService(userRepository, passwordEncoder);
+    }
+
+    @Test
+    void signup_persistsBcryptHashedPassword() {
+        SignupRequest request = new SignupRequest("alice", "pw1234!", "앨리스");
+        when(userRepository.existsByUsername("alice")).thenReturn(false);
+        when(userRepository.save(any(User.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        userService.signup(request);
+
+        ArgumentCaptor<User> captor = ArgumentCaptor.forClass(User.class);
+        verify(userRepository).save(captor.capture());
+        User saved = captor.getValue();
+        assertThat(saved.getUsername()).isEqualTo("alice");
+        assertThat(saved.getNickname()).isEqualTo("앨리스");
+        assertThat(saved.getPassword()).startsWith("$2a$");
+        assertThat(passwordEncoder.matches("pw1234!", saved.getPassword())).isTrue();
+    }
+
+    @Test
+    void signup_throwsOnDuplicateUsername_preCheck() {
+        SignupRequest request = new SignupRequest("alice", "pw1234!", "앨리스");
+        when(userRepository.existsByUsername("alice")).thenReturn(true);
+
+        assertThatThrownBy(() -> userService.signup(request))
+                .isInstanceOf(DataIntegrityViolationException.class);
+        verify(userRepository, never()).save(any());
+    }
+
+    @Test
+    void signup_propagatesDataIntegrityFromSave_raceCondition() {
+        SignupRequest request = new SignupRequest("alice", "pw1234!", "앨리스");
+        when(userRepository.existsByUsername("alice")).thenReturn(false);
+        when(userRepository.save(any(User.class)))
+                .thenThrow(new DataIntegrityViolationException("unique constraint"));
+
+        assertThatThrownBy(() -> userService.signup(request))
+                .isInstanceOf(DataIntegrityViolationException.class);
+    }
+}


### PR DESCRIPTION
## 요약
- `POST /api/auth/signup` 엔드포인트로 회원가입 구현 (username 중복 시 409, 검증 실패 시 400, 성공 시 201)
- BCrypt 로 해시된 비밀번호만 저장. 평문은 서비스 계층에서만 다룸
- 최소 `SecurityConfig` + `PasswordEncoder` bean 설정 (로그인/세션은 #8 에서)

## 맥락 / 관련 이슈
- Closes #7

## 변경 내역
**프로덕션 (7)**
- `user/User.java` — JPA 엔티티 (id, username unique, password BCrypt, nickname, createdAt)
- `user/UserRepository.java` — `existsByUsername`, `findByUsername`
- `user/dto/SignupRequest.java` — record + `@NotBlank` / `@Size` 제약
- `user/UserService.java` — `signup()` = pre-check 중복 + BCrypt 해시 + save, `@Transactional`
- `user/AuthController.java` — `POST /api/auth/signup` (`@Valid` 트리거)
- `config/SecurityConfig.java` — signup/h2-console `permitAll`, CSRF off, `BCryptPasswordEncoder` bean
- `common/GlobalExceptionHandler.java` — `MethodArgumentNotValidException` → 400, `DataIntegrityViolationException` → 409

**테스트 (2)**
- `UserServiceTest.java` — 3케이스: BCrypt 해시 저장 / 중복 pre-check / race(save 에서 DIV throw)
- `AuthControllerTest.java` — 11케이스: 9 validation 400 (ParameterizedTest) + 201 + 409

**설정 (1)**
- `build.gradle.kts` — Lombok 의존성 추가 (`@Getter`, `@NoArgsConstructor`, `@RequiredArgsConstructor`)

## TDD 체크리스트 (CLAUDE.md)
- [x] 모든 프로덕션 코드에 대응하는 테스트가 있다
- [x] RED 단계에서 설계한 edge case 가 테스트로 박혀 있다 — username null/blank/3미만/50초과, password null/blank/6미만, nickname null/blank, 중복 pre-check, 중복 race condition
- [x] 테스트를 지우거나 `@Disabled` 처리하지 않았다
- [x] `./gradlew test` 전체 초록이다 (15/15)

## 작업 단위 규약 (CLAUDE.md)
- [x] 수정/생성 파일 10개 이하 (1 수정 + 10 생성 = 경계 충족, 생성 파일은 모두 새 책임 영역)
- [x] 모든 파일 300줄 미만 (최대 `AuthControllerTest.java` ~85줄)

## RED → GREEN → REFACTOR 커밋 분리
- `c541400` **test(#7)**: RED — 9개 RED 테스트 + 도메인 스켈레톤. 이 커밋 체크아웃 후 `./gradlew test` 는 의도적으로 4개 실패 (service 3 + controller 409 1).
- `138f0d8` **feat(#7)**: GREEN — `UserService.signup` 실제 구현 + `GlobalExceptionHandler` 생성. 15/15 초록.
- `2ac7f5a` **refactor(#7)**: `ErrorResponse` 빌더 DRY — 두 핸들러의 중복을 private `build(...)` 로 통합.

## 로컬 검증 로그
```
$ ./gradlew test
BUILD SUCCESSFUL — 15 tests, 0 failed

$ curl -X POST http://localhost:8080/api/auth/signup -H 'Content-Type: application/json' \
    -d '{"username":"alice","password":"pw1234!","nickname":"앨리스"}'
HTTP 201

# 동일 요청 재시도
HTTP 409

# 빈 username
HTTP 400

# 6자 미만 password
HTTP 400
```

## 범위 밖 (다음 이슈에서)
- `CustomUserDetailsService` / 로그인 폼 / 세션 → #8
- `@SpringBootTest` 기반 통합 테스트 인프라 → #8 (로그인 플로우 검증 시 자연히 필요)
- 부팅 시 Spring Security 가 기본 `InMemoryUserDetailsManager` 의 generated password 를 로그에 남기지만, #8 에서 교체되므로 #7 에서는 허용

🤖 Generated with [Claude Code](https://claude.com/claude-code)