### PR TITLE
chore(#15): Playwright 테스트 인프라 도입 — JVM 바인딩 + 시스템 Chrome

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,11 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x ./gradlew
 
+      - name: Setup Chrome (for Playwright E2E)
+        uses: browser-actions/setup-chrome@v1
+        with:
+          chrome-version: stable
+
       - name: Gradle build (compile + test)
         run: ./gradlew build --no-daemon
 

--- a/README.md
+++ b/README.md
@@ -229,6 +229,16 @@ sequenceDiagram
 #   JDBC URL: jdbc:h2:mem:boarddb
 ```
 
+### 7.1 테스트 실행
+
+```bash
+./gradlew test
+```
+
+MockMvc/단위 테스트와 Playwright 기반 E2E 테스트가 함께 실행됩니다.
+
+**E2E 전제조건**: 로컬에 **Google Chrome** 이 설치되어 있어야 합니다. Playwright 는 번들 Chromium 다운로드를 우회(`PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1`) 하고 시스템 Chrome(`channel="chrome"`) 을 사용합니다. CI 에서는 `browser-actions/setup-chrome` 액션이 자동 설치합니다.
+
 ### 7.1 시나리오 테스트 (curl)
 
 ```bash

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,6 +27,7 @@ dependencies {
 	runtimeOnly("com.h2database:h2")
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 	testImplementation("org.springframework.security:spring-security-test")
+	testImplementation("com.microsoft.playwright:playwright:1.49.0")
 	testCompileOnly("org.projectlombok:lombok")
 	testAnnotationProcessor("org.projectlombok:lombok")
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
@@ -34,4 +35,5 @@ dependencies {
 
 tasks.withType<Test> {
 	useJUnitPlatform()
+	environment("PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD", "1")
 }

--- a/src/test/java/com/example/board/e2e/PlaywrightSmokeTest.java
+++ b/src/test/java/com/example/board/e2e/PlaywrightSmokeTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.microsoft.playwright.Browser;
 import com.microsoft.playwright.BrowserContext;
+import com.microsoft.playwright.BrowserType;
 import com.microsoft.playwright.Page;
 import com.microsoft.playwright.Playwright;
 import org.junit.jupiter.api.AfterAll;
@@ -23,8 +24,12 @@ class PlaywrightSmokeTest {
 
     @BeforeAll
     static void launchBrowser() {
+        // channel("chrome") = system-installed Google Chrome. 번들 Chromium 다운로드를
+        // 우회하기 위해 build.gradle.kts 의 test 태스크에서
+        // PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 을 세팅함.
         playwright = Playwright.create();
-        browser = playwright.chromium().launch();
+        browser = playwright.chromium().launch(
+                new BrowserType.LaunchOptions().setChannel("chrome"));
     }
 
     @AfterAll

--- a/src/test/java/com/example/board/e2e/PlaywrightSmokeTest.java
+++ b/src/test/java/com/example/board/e2e/PlaywrightSmokeTest.java
@@ -1,0 +1,48 @@
+package com.example.board.e2e;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.microsoft.playwright.Browser;
+import com.microsoft.playwright.BrowserContext;
+import com.microsoft.playwright.Page;
+import com.microsoft.playwright.Playwright;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class PlaywrightSmokeTest {
+
+    @LocalServerPort
+    int port;
+
+    static Playwright playwright;
+    static Browser browser;
+
+    @BeforeAll
+    static void launchBrowser() {
+        playwright = Playwright.create();
+        browser = playwright.chromium().launch();
+    }
+
+    @AfterAll
+    static void closeBrowser() {
+        if (browser != null) {
+            browser.close();
+        }
+        if (playwright != null) {
+            playwright.close();
+        }
+    }
+
+    @Test
+    void h2ConsoleLoadsInChromium() {
+        try (BrowserContext context = browser.newContext();
+             Page page = context.newPage()) {
+            page.navigate("http://localhost:" + port + "/h2-console");
+            assertThat(page.title()).containsIgnoringCase("h2 console");
+        }
+    }
+}


### PR DESCRIPTION
## 요약
- Playwright JVM 바인딩(`com.microsoft.playwright:playwright:1.49.0`) 을 테스트 의존성으로 도입
- `PlaywrightSmokeTest` 로 `@SpringBootTest(RANDOM_PORT)` + 실제 Chromium 으로 `/h2-console` 접속 스모크 검증
- **번들 Chromium 다운로드 우회** — `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1` + `channel="chrome"` 조합으로 시스템 Chrome 사용
- CI 워크플로우에 `browser-actions/setup-chrome@v1` 스텝 추가

## 맥락 / 관련 이슈
- Closes #15

## 변경 내역
**수정 (3)**
- `build.gradle.kts` — Playwright 의존성 + test 태스크 환경변수 `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1`
- `.github/workflows/ci.yml` — Chrome 설치 스텝 (`browser-actions/setup-chrome@v1`, stable)
- `README.md` — §7.1 테스트 실행 섹션 (E2E 로컬 전제조건/CI 자동 설치 안내)

**생성 (1)**
- `src/test/java/com/example/board/e2e/PlaywrightSmokeTest.java` — `@SpringBootTest(webEnvironment=RANDOM_PORT)` + Playwright Chromium → `/h2-console` 접속 → 페이지 타이틀 "H2 Console" assert

## TDD 체크리스트 (CLAUDE.md)
- [x] 모든 프로덕션 코드에 대응하는 테스트가 있다 — 이 이슈 자체가 테스트 인프라. 스모크 테스트가 파이프라인 동작을 증명
- [x] RED 단계에서 edge case 테스트 — 의존성 부재 시 컴파일 실패 (RED 커밋에서 재현)
- [x] `@Disabled` 미사용
- [x] `./gradlew test` 전체 초록 (16/16: 기존 15 + Playwright 1)

## 작업 단위 규약 (CLAUDE.md)
- [x] 수정/생성 파일 4개 (≤10)
- [x] 모든 파일 300줄 미만

## RED → GREEN 커밋 분리
- `80526ae` **test(#15)**: RED — PlaywrightSmokeTest (의존성 부재 → 컴파일 실패). 이 커밋 상태 `./gradlew compileTestJava` 는 "package com.microsoft.playwright does not exist" 로 실패.
- `93cfe37` **chore(#15)**: GREEN — 의존성 + 시스템 Chrome 조합 + CI 설정
- `f443f91` **docs(#15)**: README E2E 실행 안내

## 네트워크 이슈 대응 노트
로컬 시도 중 Playwright 번들 Chromium 다운로드 (`playwright-verizon.azureedge.net`) 가 현재 네트워크에서 차단됨을 발견. 해결책:
- `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1` 로 자동 다운로드 비활성
- `chromium().launch(setChannel("chrome"))` 로 시스템 설치 Chrome 사용
- 로컬: macOS Google Chrome.app 사용 (확인됨)
- CI: `browser-actions/setup-chrome` 가 stable 버전 설치

## 로컬 검증
```
$ ./gradlew test
BUILD SUCCESSFUL — 16 tests, 0 failed (UserServiceTest 3 + AuthControllerTest 11 + BoardApplicationTests 1 + PlaywrightSmokeTest 1)
```

## 다음 단계 (후속 이슈)
- **#14** UI 기반 (Thymeleaf + Tailwind + Claude 토큰) — MockMvc 사용
- **#16** UI 프로토타입 화면 — 본 PR 의 Playwright 위에서 실제 UI 상호작용 E2E 작성 (signup 폼 제출, 게시판 클릭 등)

🤖 Generated with [Claude Code](https://claude.com/claude-code)