### PR TITLE
chore(#18): CI 에 JaCoCo 커버리지 + Codecov 연동

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,8 +36,19 @@ jobs:
         with:
           chrome-version: stable
 
-      - name: Gradle build (compile + test)
-        run: ./gradlew build --no-daemon
+      - name: Run tests with coverage
+        run: ./gradlew test jacocoTestReport --no-daemon
+
+      - name: Upload coverage to Codecov
+        if: always()
+        uses: codecov/codecov-action@v5
+        with:
+          files: build/reports/jacoco/test/jacocoTestReport.xml
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
+
+      - name: Build (without re-running tests)
+        run: ./gradlew build -x test --no-daemon
 
       - name: Upload test reports on failure
         if: failure()

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # AX 게시판 (Spring Boot)
 
+[![CI](https://github.com/myeongseogDihisoft/ax/actions/workflows/ci.yml/badge.svg)](https://github.com/myeongseogDihisoft/ax/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/myeongseogDihisoft/ax/branch/main/graph/badge.svg)](https://codecov.io/gh/myeongseogDihisoft/ax)
+
 > 회원가입 · 로그인 · 게시글 CRUD를 제공하는 최소 기능 게시판 백엔드 스펙 문서
 
 본 문서는 **구현 이전 단계의 스펙 정의**입니다. 이 README만 보고도 동일한 결과물을 구현할 수 있도록 요구사항·도메인·API·정책을 일관된 형태로 기술합니다.
@@ -238,6 +241,22 @@ sequenceDiagram
 MockMvc/단위 테스트와 Playwright 기반 E2E 테스트가 함께 실행됩니다.
 
 **E2E 전제조건**: 로컬에 **Google Chrome** 이 설치되어 있어야 합니다. Playwright 는 번들 Chromium 다운로드를 우회(`PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1`) 하고 시스템 Chrome(`channel="chrome"`) 을 사용합니다. CI 에서는 `browser-actions/setup-chrome` 액션이 자동 설치합니다.
+
+#### 커버리지 리포트
+
+`./gradlew test` 는 JaCoCo 리포트를 자동 생성합니다 (`finalizedBy(jacocoTestReport)`).
+
+```bash
+./gradlew test jacocoTestReport
+
+# XML (Codecov 업로드 용)
+build/reports/jacoco/test/jacocoTestReport.xml
+
+# HTML (브라우저 열람 용)
+open build/reports/jacoco/test/html/index.html
+```
+
+CI 에서는 `codecov/codecov-action@v5` 가 XML 리포트를 Codecov 로 업로드합니다. PR 마다 커버리지 변화 리포트가 자동 코멘트로 달립니다.
 
 ### 7.1 시나리오 테스트 (curl)
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
 	java
+	jacoco
 	id("org.springframework.boot") version "3.5.13"
 	id("io.spring.dependency-management") version "1.1.7"
 }
@@ -33,7 +34,20 @@ dependencies {
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 
+jacoco {
+	toolVersion = "0.8.11"
+}
+
 tasks.withType<Test> {
 	useJUnitPlatform()
 	environment("PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD", "1")
+	finalizedBy(tasks.jacocoTestReport)
+}
+
+tasks.jacocoTestReport {
+	dependsOn(tasks.test)
+	reports {
+		xml.required.set(true)
+		html.required.set(true)
+	}
 }


### PR DESCRIPTION
Closes #18

## 요약

- CI 의 단일 `gradle build` 스텝을 **test → coverage upload → build** 3 단계로 분리
- JaCoCo 로 커버리지 측정 (XML + HTML 리포트)
- `codecov/codecov-action@v5` 로 Codecov 업로드
- README 에 CI/Codecov 뱃지 + 커버리지 실행 안내 추가

## 변경 파일 (3)

| 파일 | 변경 |
|---|---|
| `build.gradle.kts` | jacoco 플러그인 + `tasks.test.finalizedBy(jacocoTestReport)` + XML/HTML 리포트 |
| `.github/workflows/ci.yml` | test/upload/build 3 스텝 분리, Codecov v5 업로드 |
| `README.md` | CI + Codecov 뱃지, §7.1 커버리지 리포트 안내 |

## 사용자 사전 작업 ⚠️

Codecov 대시보드 데이터 누적을 위해 **토큰 등록이 필요**합니다 (없어도 CI 자체는 통과).

1. https://app.codecov.io/ 에서 GitHub 로그인 → `myeongseogDihisoft/ax` 활성화
2. Upload Token 복사
3. GitHub → Settings → Secrets and variables → Actions → `CODECOV_TOKEN` secret 등록

## 로컬 검증 완료

- ``./gradlew clean test jacocoTestReport` → BUILD SUCCESSFUL
- `build/reports/jacoco/test/jacocoTestReport.xml` (14.8K) 생성 확인
- 기존 테스트 스위트 모두 초록

## Test plan

- [ ] PR CI 에서 "Run tests with coverage" 스텝 초록
- [ ] "Upload coverage to Codecov" 스텝 실행 (토큰 없으면 skip/warning)
- [ ] Codecov 토큰 등록 후 대시보드에 수치 확인
- [ ] README 뱃지가 GitHub 에서 정상 렌더링

🤖 Generated with [Claude Code](https://claude.com/claude-code)