### PR TITLE
chore(#20): Codecov 커버리지 목표 설정 (codecov.yml)

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,28 @@
+# Codecov 커버리지 정책
+# 문서: https://docs.codecov.com/docs/codecovyml-reference
+
+coverage:
+  precision: 1
+  round: down
+  range: "70...95"
+
+  status:
+    project:
+      default:
+        target: 90%
+        threshold: 2%
+        informational: false
+        if_ci_failed: error
+    patch:
+      default:
+        target: 80%
+        threshold: 0%
+        if_ci_failed: error
+
+comment:
+  layout: "reach, diff, flags, files"
+  behavior: default
+  require_changes: false
+
+ignore:
+  - "src/main/java/com/example/board/BoardApplication.java"


### PR DESCRIPTION
Closes #20

## 요약

PR #19 로 구축한 Codecov 연동 위에 **목표치** 를 박음. 앞으로 테스트 없이 프로덕션 코드만 추가되는 PR 은 Codecov check 가 빨강으로 표시됨.

## 현재 baseline

| Type | Cov |
|---|---|
| INSTRUCTION | 97.4% |
| BRANCH | 100% |
| LINE | 95.2% |

## 설정값

| 항목 | 값 | 근거 |
|---|---|---|
| `project.default.target` | **90%** | baseline 97.4% 에서 7.4%p 여유 |
| `project.default.threshold` | **2%** | 단일 PR 2%p 하락까지 허용 |
| `patch.default.target` | **80%** | 신규/변경 라인 하한 |
| `ignore` | `BoardApplication.java` | `main()` 만 있는 Spring Boot 진입점 |

## 검증

- [x] YAML 문법 파싱 (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] Codecov validate API (`curl -X POST https://codecov.io/validate`) → `Valid!`
- [ ] PR Codecov bot 코멘트에 target 90% / patch 80% 기준 표시 확인
- [ ] 현재 coverage 를 그대로 유지하는 변경이므로 양쪽 check 초록 예상

## 후속 기대 동작

- #8 로그인 / #9 게시글 CRUD 등 다음 feature PR 에서 테스트 없이 프로덕션 코드만 추가하면 patch check 빨강
- 리팩토링 중 일시적 hit 는 2%p threshold 안이면 통과

## Out of Scope

- JaCoCo `jacocoTestCoverageVerification` 로컬 빌드 강제 (Option A — 선택지에서 배제)
- Flags (UNIT vs E2E 분리) — 현재 단일 test job

🤖 Generated with [Claude Code](https://claude.com/claude-code)