### PR TITLE
chore(#22): CI job 분리 — build / test+coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,31 @@ concurrency:
 
 jobs:
   build:
-    name: Gradle build + test (JDK 17)
+    name: Build (JDK 17, no tests)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17 (Temurin)
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Setup Gradle (with cache)
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x ./gradlew
+
+      - name: Gradle build (compile + assemble, no tests)
+        run: ./gradlew build -x test --no-daemon
+
+  test:
+    name: Test + Coverage (JDK 17)
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
@@ -46,9 +70,6 @@ jobs:
           files: build/reports/jacoco/test/jacocoTestReport.xml
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
-
-      - name: Build (without re-running tests)
-        run: ./gradlew build -x test --no-daemon
 
       - name: Upload test reports on failure
         if: failure()


### PR DESCRIPTION
Closes #22

## 요약

CI 의 단일 job 내부 직렬 구조를 **2 개 job 병렬 실행** 으로 분리.

## Before / After

**Before** (단일 job, 직렬)
```
build:
  - Run tests with coverage     (5~6m, Chrome 포함)
  - Upload coverage to Codecov
  - Build (without re-running tests)
```

**After** (2 job, 병렬)
```
build:                           test:
  - Gradle build -x test          - Run tests with coverage
                                  - Upload coverage to Codecov
                                  - Upload test reports on failure
```

## 변경 파일

| 경로 | 변경 |
|---|---|
| `.github/workflows/ci.yml` | `jobs.build` + `jobs.test` 2 개 job. build 는 Chrome 생략 / 10m timeout, test 는 Chrome 포함 / 15m timeout |

## 기대 효과

- 컴파일 에러 / 테스트 실패 각자 독립 표시 → 원인 파악 빠름
- build 가 test 를 기다리지 않음 → 병렬 피드백
- build job 은 Chrome 설치 생략 → CI 리소스 절약

## 로컬 검증

- [x] `./gradlew build -x test` → BUILD SUCCESSFUL (3s)
- [x] `./gradlew test jacocoTestReport` → BUILD SUCCESSFUL (PR #19 에서 이미 검증)
- [x] YAML 파싱 OK, 2 jobs 확인

## Test plan

- [ ] PR check 에 `Build (JDK 17, no tests)` / `Test + Coverage (JDK 17)` 2 개가 따로 표시되는지
- [ ] 두 job 이 병렬로 시작되는지 (Actions 타임라인)
- [ ] test job 에서 Codecov 업로드 계속 정상 동작

## Out of Scope

- Matrix build (JDK 17 + 21)
- Playwright 전용 별도 job
- 캐시 공유

🤖 Generated with [Claude Code](https://claude.com/claude-code)